### PR TITLE
Fix issue with IsTuple in Win10 FCU / .NET 4.7.1

### DIFF
--- a/src/ht4o/Extensions/TypeExtensions.cs
+++ b/src/ht4o/Extensions/TypeExtensions.cs
@@ -52,7 +52,7 @@ namespace Hypertable.Persistence.Extensions
         /// <summary>
         /// The ITuple type.
         /// </summary>
-        private static readonly Type TypeITuple = typeof(Tuple<int>).GetInterface("System.ITuple");
+        private static readonly Type TypeITuple = typeof(Tuple<int>).GetInterface("System.ITuple") ?? typeof(Tuple<int>).GetInterface("System.Runtime.CompilerServices.ITuple");
 
         #endregion
 


### PR DESCRIPTION
Crashed with NullReferenceException in Windows 10 Fall Creators Update because System.ITuple is not used anymore. Most likely caused by .NET 4.7.1 that is included in this update and will also happen if installed in some other way. 
Might make sense to also have the IsTuple() extension fail more gracefully should TypeITuple still be null or use a different approach altogether.