### PR TITLE
Target .net standard for ht4o.Serializer

### DIFF
--- a/ht4o.sln
+++ b/ht4o.sln
@@ -1,51 +1,81 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31129.286
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ht4o", "src\ht4o\ht4o.csproj", "{492EC4F9-6694-48FE-99BF-E773D0B664DD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ht4o.Serialization", "src\ht4o.Serialization\ht4o.Serialization.csproj", "{20B09F8E-7106-49D4-A125-54B05719B3A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ht4o.Serialization", "src\ht4o.Serialization\ht4o.Serialization.csproj", "{20B09F8E-7106-49D4-A125-54B05719B3A0}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{83287D77-7B2E-4330-B0A3-658C1216099F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ht4o.Test", "src\ht4o.Test\ht4o.Test.csproj", "{966986C3-4B6F-40B9-B2D7-26100A746507}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ht4o.Serialization.Test", "src\ht4o.Serialization.Test\ht4o.Serialization.Test.csproj", "{99FB249E-3796-4731-8AA9-2E7623F96B65}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
 		Debug|Win32 = Debug|Win32
 		Debug|x64 = Debug|x64
+		Release|Any CPU = Release|Any CPU
 		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{492EC4F9-6694-48FE-99BF-E773D0B664DD}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{492EC4F9-6694-48FE-99BF-E773D0B664DD}.Debug|Win32.ActiveCfg = Debug|x86
 		{492EC4F9-6694-48FE-99BF-E773D0B664DD}.Debug|Win32.Build.0 = Debug|x86
 		{492EC4F9-6694-48FE-99BF-E773D0B664DD}.Debug|x64.ActiveCfg = Debug|x64
 		{492EC4F9-6694-48FE-99BF-E773D0B664DD}.Debug|x64.Build.0 = Debug|x64
+		{492EC4F9-6694-48FE-99BF-E773D0B664DD}.Release|Any CPU.ActiveCfg = Release|x86
 		{492EC4F9-6694-48FE-99BF-E773D0B664DD}.Release|Win32.ActiveCfg = Release|x86
 		{492EC4F9-6694-48FE-99BF-E773D0B664DD}.Release|Win32.Build.0 = Release|x86
 		{492EC4F9-6694-48FE-99BF-E773D0B664DD}.Release|x64.ActiveCfg = Release|x64
 		{492EC4F9-6694-48FE-99BF-E773D0B664DD}.Release|x64.Build.0 = Release|x64
+		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Debug|Win32.ActiveCfg = Debug|Any CPU
 		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Debug|Win32.Build.0 = Debug|Any CPU
 		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Debug|x64.Build.0 = Debug|Any CPU
+		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Release|Any CPU.Build.0 = Release|Any CPU
 		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Release|Win32.ActiveCfg = Release|Any CPU
 		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Release|Win32.Build.0 = Release|Any CPU
 		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Release|x64.ActiveCfg = Release|Any CPU
 		{20B09F8E-7106-49D4-A125-54B05719B3A0}.Release|x64.Build.0 = Release|Any CPU
+		{966986C3-4B6F-40B9-B2D7-26100A746507}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{966986C3-4B6F-40B9-B2D7-26100A746507}.Debug|Win32.ActiveCfg = Debug|x86
 		{966986C3-4B6F-40B9-B2D7-26100A746507}.Debug|Win32.Build.0 = Debug|x86
 		{966986C3-4B6F-40B9-B2D7-26100A746507}.Debug|x64.ActiveCfg = Debug|x64
 		{966986C3-4B6F-40B9-B2D7-26100A746507}.Debug|x64.Build.0 = Debug|x64
+		{966986C3-4B6F-40B9-B2D7-26100A746507}.Release|Any CPU.ActiveCfg = Release|x86
 		{966986C3-4B6F-40B9-B2D7-26100A746507}.Release|Win32.ActiveCfg = Release|x86
 		{966986C3-4B6F-40B9-B2D7-26100A746507}.Release|Win32.Build.0 = Release|x86
 		{966986C3-4B6F-40B9-B2D7-26100A746507}.Release|x64.ActiveCfg = Release|x64
 		{966986C3-4B6F-40B9-B2D7-26100A746507}.Release|x64.Build.0 = Release|x64
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Debug|Win32.ActiveCfg = Debug|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Debug|Win32.Build.0 = Debug|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Debug|x64.Build.0 = Debug|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Release|Win32.ActiveCfg = Release|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Release|Win32.Build.0 = Release|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Release|x64.ActiveCfg = Release|Any CPU
+		{99FB249E-3796-4731-8AA9-2E7623F96B65}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{966986C3-4B6F-40B9-B2D7-26100A746507} = {83287D77-7B2E-4330-B0A3-658C1216099F}
+		{99FB249E-3796-4731-8AA9-2E7623F96B65} = {83287D77-7B2E-4330-B0A3-658C1216099F}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D44A9E96-B72B-4932-B2CB-26983CCC4543}
 	EndGlobalSection
 EndGlobal

--- a/src/ht4o.Serialization.Test/ht4o.Serialization.Test.csproj
+++ b/src/ht4o.Serialization.Test/ht4o.Serialization.Test.csproj
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <RootNamespace>Hypertable.Persistence.Test.Serialization</RootNamespace>
+    <AssemblyName>ht4o.Serialization.Test</AssemblyName>
+    <TargetFramework>net48</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>..\..\dist\$(VisualStudioVersion)\$(Platform)\$(Configuration)\tests</OutputPath>
+    <IntermediateOutputPath>..\..\build\$(VisualStudioVersion)\$(AssemblyName)\$(Platform)\$(Configuration)</IntermediateOutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
+    <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+    <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+    <NoWarn>1587</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath>..\..\dist\$(VisualStudioVersion)\$(Platform)\$(Configuration)\tests</OutputPath>
+    <IntermediateOutputPath>..\..\build\$(VisualStudioVersion)\$(AssemblyName)\$(Platform)\$(Configuration)</IntermediateOutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisIgnoreBuiltInRuleSets>true</CodeAnalysisIgnoreBuiltInRuleSets>
+    <CodeAnalysisIgnoreBuiltInRules>true</CodeAnalysisIgnoreBuiltInRules>
+    <CodeAnalysisFailOnMissingRules>false</CodeAnalysisFailOnMissingRules>
+    <NoWarn>1587</NoWarn>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <CodeAnalysisDependentAssemblyPaths Condition=" '$(VS100COMNTOOLS)' != '' " Include="$(VS100COMNTOOLS)..\IDE\PrivateAssemblies">
+      <Visible>False</Visible>
+    </CodeAnalysisDependentAssemblyPaths>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\ht4o.Test\Properties\AssemblyInfo.cs" />
+    <Compile Include="..\ht4o.Test\Common\Equatable.cs" />
+    <Compile Include="..\ht4o.Test\Common\Rng.cs" />
+    <Compile Include="..\ht4o.Test\Serialization\TestSerialization.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\ht4o.Test\App.config">
+      <SubType>Designer</SubType>
+    </None>
+    <None Include="..\ht4o.Test\Settings.StyleCop" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ht4o.Serialization\ht4o.Serialization.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/ht4o.Serialization/ht4o.Serialization.csproj
+++ b/src/ht4o.Serialization/ht4o.Serialization.csproj
@@ -1,17 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{20B09F8E-7106-49D4-A125-54B05719B3A0}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Hypertable.Persistence</RootNamespace>
     <AssemblyName>ht4o.Serialization</AssemblyName>
-    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == ''">v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\..\dist\$(VisualStudioVersion)\AnyCPU\Debug\</OutputPath>
@@ -31,6 +26,7 @@
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>..\..\dist\$(VisualStudioVersion)\AnyCPU\Release\</OutputPath>
     <DefineConstants>TRACE;HT4O_SERIALIZATION</DefineConstants>
@@ -49,17 +45,12 @@
     <Prefer32Bit>false</Prefer32Bit>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Buffers.4.5.0\lib\netstandard1.1\System.Buffers.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Core" />
-    <Reference Include="System.Runtime.Serialization" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\ht4o\Attributes\IgnoreAttribute.cs" />
     <Compile Include="..\ht4o\Attributes\TransientAttribute.cs" />
     <Compile Include="..\ht4o\Collections\ChunkedCollection.cs" />
@@ -120,15 +111,4 @@
     <Compile Include="..\ht4o\Serialization\TypeSchemaProperty.cs" />
     <Compile Include="..\ht4o\Serialization\WritableMemoryStream.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/ht4o.Serialization/packages.config
+++ b/src/ht4o.Serialization/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="System.Buffers" version="4.5.0" targetFramework="net452" />
-</packages>

--- a/src/ht4o.Test/Serialization/TestSerialization.cs
+++ b/src/ht4o.Test/Serialization/TestSerialization.cs
@@ -1291,6 +1291,15 @@ namespace Hypertable.Persistence.Test.Serialization
     {
         #region Public Methods and Operators
 
+        [ClassInitialize]
+#pragma warning disable IDE0060 // Remove unused parameter
+        public static void ClassInitialize(TestContext unused)
+#pragma warning restore IDE0060 // Remove unused parameter
+        {
+            // Required for Double String serialization
+            System.Globalization.CultureInfo.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+        }
+
         /// <summary>
         /// The test anonymous object array.
         /// </summary>

--- a/src/ht4o/Logging.cs
+++ b/src/ht4o/Logging.cs
@@ -230,7 +230,6 @@ namespace Hypertable.Persistence
 #if DEBUG
                 var listeners = new List<TraceListener>();
                 listeners.AddRange(Trace.Listeners.OfType<TraceListener>());
-                listeners.AddRange(Debug.Listeners.OfType<TraceListener>());
 
                 foreach (var listener in listeners)
                 {


### PR DESCRIPTION
This PR introduces the following changes: 

- Migrated the ht4o serializer project to a SDK style project (required for .net standard) 
- Retargeted ht4o serializer to .net standard 2.0
- Added a new project for testing the serializer only because full ht4o cannot be built locally